### PR TITLE
Support hhvm 4.69+

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 tests/ export-ignore
+test_subjects/ export-ignore
 .hhconfig export-ignore

--- a/.hhconfig
+++ b/.hhconfig
@@ -1,0 +1,2 @@
+allowed_decl_fixme_codes=2053
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4107,4108,4110,4128,4133,4135,4188,4240,4323


### PR DESCRIPTION
Adds hhconfig directives required for hhvm 4.62.
These directives are only required when fip is the top level project.
Dependents don't need these directives.
Removes test_subjects from the export.